### PR TITLE
Should we refactor to use React Context?

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,19 +1,28 @@
-import { useState } from 'react';
+//import { useState } from 'react';
 import useFetch from './common/use-fetch';
-import { sortByPopularity, filterStations } from './common/utilities';
+import useStationsState from './common/use-stations-state';
+//import { sortByPopularity, filterStations } from './common/utilities';
 import Filters from './components/Filters/Filters';
 import StationsList from './components/StationsList/StationsList';
 import NowPlaying from './components/NowPlaying/NowPlaying';
 import './App.scss';
+import { StationsContext } from './common/StationsContext';
 
 const TUNEIN_API = 'https://s3-us-west-1.amazonaws.com/cdn-web.tunein.com/stations.json';
 
 function App() {
   const { allStations } = useFetch(TUNEIN_API);
-  const [filteredStations, setFilteredStations] = useState(null);
-  const [activeFilter, setActiveFilter] = useState('');
-  const [stationNowPlaying, setStationNowPlaying] = useState('');
-  
+  //const [filteredStations, setFilteredStations] = useState(null);
+  //const [activeFilter, setActiveFilter] = useState('');
+  //const [stationNowPlaying, setStationNowPlaying] = useState('');
+  const {
+    filteredStations,
+    activeFilter,
+    stationNowPlaying,
+    clickStation,
+    clickFilter
+  } = useStationsState();
+  /*
   const clickStation = station => {
     setStationNowPlaying(station);
   }
@@ -27,21 +36,23 @@ function App() {
         setFilteredStations(filterStations(allStations, filter));
       }
   }
-  
+  */
   // Find and return the station object
   const getStation = (filter) => allStations?.filter(station => station.id === stationNowPlaying);
 
   return (
-  	<div className="app">
-      <div>
-        <h2>Find stations</h2>
-        <Filters active={activeFilter} handleClick={clickFilter} />
-        <StationsList
-          stations={filteredStations || allStations}
-          handleClickStation={clickStation} />
+  	<StationsContext.Provider value={allStations}>
+      <div className="app">
+        <div>
+          <h2>Find stations</h2>
+          <Filters active={activeFilter} handleClick={clickFilter} />
+          <StationsList
+            stations={filteredStations || allStations}
+            handleClickStation={clickStation} />
+        </div>
+        <NowPlaying station={getStation(stationNowPlaying)} />
       </div>
-      <NowPlaying station={getStation(stationNowPlaying)} />
-  	</div>
+    </StationsContext.Provider>
   );
 }
 

--- a/src/common/StationsContext.js
+++ b/src/common/StationsContext.js
@@ -1,5 +1,3 @@
 import { createContext } from "react";
 
-const StationsContext = createContext();
-
-export default StationsContext;
+export const StationsContext = createContext(); // Needs default value? []

--- a/src/common/StationsContext.js
+++ b/src/common/StationsContext.js
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const StationsContext = createContext();
+
+export default StationsContext;

--- a/src/common/use-stations-state.js
+++ b/src/common/use-stations-state.js
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState } from 'react';
-import StationsContext from './StationsContext';
+import { StationsContext } from './StationsContext';
+import { sortByPopularity, filterStations } from './utilities'
 
 const useStationsState = () => {
     const allStations = useContext(StationsContext);
@@ -16,6 +17,7 @@ const useStationsState = () => {
     };
 
     const clickFilter = filter => {
+        console.log('activeFilter = ' + activeFilter); // returns empty string
         if (filter === activeFilter) {
             return;
         } else if (filter === 'popular') {

--- a/src/common/use-stations-state.js
+++ b/src/common/use-stations-state.js
@@ -1,0 +1,39 @@
+import { useContext, useEffect, useState } from 'react';
+import StationsContext from './StationsContext';
+
+const useStationsState = () => {
+    const allStations = useContext(StationsContext);
+    const [filteredStations, setFilteredStations] = useState(null);
+    const [activeFilter, setActiveFilter] = useState('');
+    const [stationNowPlaying, setStationNowPlaying] = useState('');
+
+    useEffect(() => {
+        setFilteredStations(allStations);
+    }, [allStations]);
+
+    const clickStation = (stationId) => {
+        setStationNowPlaying(stationId);
+    };
+
+    const clickFilter = filter => {
+        if (filter === activeFilter) {
+            return;
+        } else if (filter === 'popular') {
+            setActiveFilter(filter);
+            setFilteredStations(sortByPopularity(allStations));
+        } else {
+            setActiveFilter(filter);
+            setFilteredStations(filterStations(allStations, filter));
+        }
+    };
+
+    return {
+        filteredStations,
+        activeFilter,
+        stationNowPlaying,
+        clickStation,
+        clickFilter
+    };
+};
+
+export default useStationsState;


### PR DESCRIPTION
Many components in the app need the same information. Use Context in the parent App component to make information available to any component in the tree below it without passing it explicitly through props.

This might be an unnecessary abstraction and a premature optimization. Upon reflection, we're not really passing props down multiple levels in the component tree. It mostly comes from App and its direct descendants.